### PR TITLE
feat(deps): Bump maximum pyo3 version to `0.29`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ delegate = "0.13.4"
 itertools = "0.14.0"
 # There can only be one `pyo3` dependency in the whole workspace, so we use a
 # loose version constraint to prevent breaking changes in dependent crates where possible.
-pyo3 = { version = ">= 0.27, < 0.29", optional = true, features = [
+pyo3 = { version = ">= 0.27, < 0.30", optional = true, features = [
     "multiple-pymethods",
 ] }
 num-traits = "0.2.19"


### PR DESCRIPTION
Matches the maximum pyo3 version constraint in the HUGR repo.

See: https://github.com/Quantinuum/hugr/blob/77816c447e1c81746b7ab3d9bda172db8852c259/Cargo.toml#L109