### PR TITLE
chore(lint): Fix loop counter lint error

### DIFF
--- a/src/algorithms/dynamic.rs
+++ b/src/algorithms/dynamic.rs
@@ -165,11 +165,9 @@ impl<N: IndexBase> DynamicTopoSort<N> {
         let ub = from_pos;
         let delta_f = self.cone(to, ub, graph, Direction::Outgoing);
         let delta_b = self.cone(from, lb, graph, Direction::Incoming);
-        let mut new_pos = to_pos;
-        for w in delta_b.into_iter().chain(delta_f) {
+        for (new_pos, w) in (to_pos..).zip(delta_b.into_iter().chain(delta_f)) {
             self.order[new_pos] = w;
             self.node_to_pos.insert(w, new_pos);
-            new_pos += 1;
         }
     }
 


### PR DESCRIPTION
```
error: the variable `new_pos` is used as a loop counter
   --> src/algorithms/dynamic.rs:169:9
    |
169 |         for w in delta_b.into_iter().chain(delta_f) {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `for (new_pos, w) in (to_pos..).zip(delta_b.into_iter().chain(delta_f))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#explicit_counter_loop
    = note: `-D clippy::explicit-counter-loop` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::explicit_counter_loop)]`

error: could not compile `portgraph` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `portgraph` (lib test) due to 1 previous error
Error: Process completed with exit code 101.
```